### PR TITLE
#18 bug(loading): LoadingScreen progess 버그 수정

### DIFF
--- a/src/components/ui/LoadingScreen.tsx
+++ b/src/components/ui/LoadingScreen.tsx
@@ -10,14 +10,16 @@ export default function LoadingScreen({progress, isComplete, onEnter}: LoadingSt
 
     useEffect(() => {
         if (progressBarRef.current && percentRef.current) {
+            const clampedProgress = Math.min(Math.max(progress, 0), 100);
+
             gsap.to(progressBarRef.current, {
-                width: `${progress}%`,
+                width: `${clampedProgress}%`,
                 duration: 0.3,
                 ease: "power2.out"
             });
 
             gsap.to(percentRef.current, {
-                textContent: Math.round(progress),
+                textContent: Math.round(clampedProgress),
                 duration: 0.3,
                 snap: {textContent: 1},
                 ease: "power2.out"


### PR DESCRIPTION
## 🛠️ 설명 (Description)

로딩 화면에서 진행률(progress)이 577% 등 비정상적인 값으로 표시되는 UI 버그를 수정했습니다.

문제는 GSAP textContent 애니메이션 적용 시
외부에서 전달되는 progress 값이 0~100 범위를 벗어나는 경우
그 값이 그대로 렌더링되면서 발생했습니다.

이번 수정에서는 progress 값을 항상 안전한 범위(0~100)로 제한하여
UI가 비정상적인 수치를 표시하지 않도록 보완했습니다.

## 📝 변경 사항 요약 (Summary)

- progress 값을 0~100 범위로 clamp 처리
- clampedProgress 변수 도입
- GSAP 애니메이션에 안전한 값만 전달
- 프로그레스 바와 퍼센트 텍스트 모두 clamp 값 사용

## 🔗 관련 이슈 (Related Issues)

- Closes #18 