### PR TITLE
#20 bug(progress): GLTF 로딩 Progress 역행 방지

### DIFF
--- a/src/components/ui/LoadingScreen.tsx
+++ b/src/components/ui/LoadingScreen.tsx
@@ -9,8 +9,12 @@ export default function LoadingScreen({progress, isComplete, onEnter}: LoadingSt
     const buttonRef = useRef<HTMLButtonElement>(null);
 
     useEffect(() => {
+        console.log('🔵 [LoadingScreen] Progress received:', progress, 'isComplete:', isComplete);
+
         if (progressBarRef.current && percentRef.current) {
             const clampedProgress = Math.min(Math.max(progress, 0), 100);
+
+            console.log('🟢 [LoadingScreen] Displaying:', clampedProgress, '%');
 
             gsap.to(progressBarRef.current, {
                 width: `${clampedProgress}%`,

--- a/src/load/GLTFLoader.ts
+++ b/src/load/GLTFLoader.ts
@@ -13,10 +13,16 @@ export function loadGLTFModel(
         const textureLoader = new THREE.TextureLoader();
 
         let maxProgress = 0;
+        const startTime = Date.now();
+        console.log('🚀 [GLTF] Loading started at:', startTime);
 
         loader.load(
             modelPath,
             async (gltf) => {
+                const onLoadTime = Date.now();
+                console.log('✅ [GLTF] onLoad triggered at:', onLoadTime, `(+${onLoadTime - startTime}ms)`);
+                console.log('📊 [GLTF] maxProgress before textures:', maxProgress);
+
                 const model = gltf.scene;
 
                 const textureLoadPromises: Promise<void>[] = [];
@@ -62,6 +68,8 @@ export function loadGLTFModel(
                     }
                 });
 
+                console.log(`🖼️ [TEXTURE] Found ${textureLoadPromises.length} textures to load`);
+
                 try {
                     let loadedCount = 0;
                     const totalTextures = textureLoadPromises.length;
@@ -69,14 +77,20 @@ export function loadGLTFModel(
                     // 각 텍스처 로딩마다 진행률 업데이트 (50% ~ 100%)
                     await Promise.all(
                         textureLoadPromises.map(async (promise) => {
+                            const textureStartTime = Date.now();
                             await promise;
+                            const textureEndTime = Date.now();
                             loadedCount++;
                             const textureProgress = 50 + (loadedCount / totalTextures) * 50;
 
                             if (textureProgress > maxProgress) {
                                 maxProgress = textureProgress;
+                                console.log(`📊 [TEXTURE ${loadedCount}/${totalTextures}] Progress: ${textureProgress.toFixed(1)}% (took ${textureEndTime - textureStartTime}ms)`);
+
                                 if (onProgress) {
                                     onProgress(textureProgress)
+                                } else {
+                                    console.warn(`⚠️ [TEXTURE ${loadedCount}/${totalTextures}] Progress IGNORED: ${textureProgress.toFixed(1)}% (maxProgress: ${maxProgress})`);
                                 }
                             }
                         })
@@ -95,6 +109,8 @@ export function loadGLTFModel(
                             mesh.material = material;
                         }
                     });
+                    const totalTime = Date.now() - startTime;
+                    console.log(`🎉 [COMPLETE] Total loading time: ${totalTime}ms, Final progress: ${maxProgress}%`);
 
                     resolve({
                         model,
@@ -106,14 +122,28 @@ export function loadGLTFModel(
                 }
             },
             (xhr) => {
+                const xhrTime = Date.now();
                 const percentComplete = (xhr.loaded / xhr.total) * 50;
+
+
+                console.log(`📥 [XHR] at ${xhrTime - startTime}ms:`, {
+                    loaded: xhr.loaded,
+                    total: xhr.total,
+                    rawPercentage: `${((xhr.loaded / xhr.total) * 100).toFixed(1)}%`,
+                    calculatedProgress: `${percentComplete.toFixed(1)}%`,
+                    currentMaxProgress: maxProgress
+                });
 
                 if (percentComplete > maxProgress) {
                     maxProgress = percentComplete;
+                    console.log(`✅ [XHR] Progress updated to: ${percentComplete.toFixed(1)}%`);
 
                     if (onProgress) {
                         onProgress(percentComplete);
+                    } else {
+                        console.warn(`⚠️ [XHR] Progress IGNORED: ${percentComplete.toFixed(1)}% (maxProgress: ${maxProgress})`);
                     }
+
                 }
             },
             reject

--- a/src/load/GLTFLoader.ts
+++ b/src/load/GLTFLoader.ts
@@ -12,17 +12,9 @@ export function loadGLTFModel(
         const loader = new GLTFLoader();
         const textureLoader = new THREE.TextureLoader();
 
-        let maxProgress = 0;
-        const startTime = Date.now();
-        console.log('🚀 [GLTF] Loading started at:', startTime);
-
         loader.load(
             modelPath,
             async (gltf) => {
-                const onLoadTime = Date.now();
-                console.log('✅ [GLTF] onLoad triggered at:', onLoadTime, `(+${onLoadTime - startTime}ms)`);
-                console.log('📊 [GLTF] maxProgress before textures:', maxProgress);
-
                 const model = gltf.scene;
 
                 const textureLoadPromises: Promise<void>[] = [];
@@ -47,7 +39,6 @@ export function loadGLTFModel(
                                     ? (child.material as THREE.MeshStandardMaterial).clone()
                                     : (child.material as THREE.MeshStandardMaterial);
 
-                                // 🔑 loadHighQualityTexture 함수 사용
                                 const texturePromise = loadHighQualityTexture(textureLoader, config.texturePath)
                                     .then((newTexture) => {
                                         meshesWithTextures.push({
@@ -68,35 +59,23 @@ export function loadGLTFModel(
                     }
                 });
 
-                console.log(`🖼️ [TEXTURE] Found ${textureLoadPromises.length} textures to load`);
-
                 try {
                     let loadedCount = 0;
                     const totalTextures = textureLoadPromises.length;
 
-                    // 각 텍스처 로딩마다 진행률 업데이트 (50% ~ 100%)
                     await Promise.all(
                         textureLoadPromises.map(async (promise) => {
-                            const textureStartTime = Date.now();
                             await promise;
-                            const textureEndTime = Date.now();
                             loadedCount++;
-                            const textureProgress = 50 + (loadedCount / totalTextures) * 50;
 
-                            if (textureProgress > maxProgress) {
-                                maxProgress = textureProgress;
-                                console.log(`📊 [TEXTURE ${loadedCount}/${totalTextures}] Progress: ${textureProgress.toFixed(1)}% (took ${textureEndTime - textureStartTime}ms)`);
+                            const progress = (loadedCount / totalTextures) * 100;
 
-                                if (onProgress) {
-                                    onProgress(textureProgress)
-                                } else {
-                                    console.warn(`⚠️ [TEXTURE ${loadedCount}/${totalTextures}] Progress IGNORED: ${textureProgress.toFixed(1)}% (maxProgress: ${maxProgress})`);
-                                }
+                            if (onProgress) {
+                                onProgress(progress);
                             }
                         })
                     );
 
-                    // 텍스처를 머티리얼에 적용
                     meshesWithTextures.forEach(({mesh, material, texture}) => {
                         material.map = texture;
                         material.needsUpdate = true;
@@ -109,9 +88,6 @@ export function loadGLTFModel(
                             mesh.material = material;
                         }
                     });
-                    const totalTime = Date.now() - startTime;
-                    console.log(`🎉 [COMPLETE] Total loading time: ${totalTime}ms, Final progress: ${maxProgress}%`);
-
                     resolve({
                         model,
                         animations: gltf.animations,
@@ -121,31 +97,7 @@ export function loadGLTFModel(
                     reject(error);
                 }
             },
-            (xhr) => {
-                const xhrTime = Date.now();
-                const percentComplete = (xhr.loaded / xhr.total) * 50;
-
-
-                console.log(`📥 [XHR] at ${xhrTime - startTime}ms:`, {
-                    loaded: xhr.loaded,
-                    total: xhr.total,
-                    rawPercentage: `${((xhr.loaded / xhr.total) * 100).toFixed(1)}%`,
-                    calculatedProgress: `${percentComplete.toFixed(1)}%`,
-                    currentMaxProgress: maxProgress
-                });
-
-                if (percentComplete > maxProgress) {
-                    maxProgress = percentComplete;
-                    console.log(`✅ [XHR] Progress updated to: ${percentComplete.toFixed(1)}%`);
-
-                    if (onProgress) {
-                        onProgress(percentComplete);
-                    } else {
-                        console.warn(`⚠️ [XHR] Progress IGNORED: ${percentComplete.toFixed(1)}% (maxProgress: ${maxProgress})`);
-                    }
-
-                }
-            },
+            undefined,
             reject
         );
     });

--- a/src/load/GLTFLoader.ts
+++ b/src/load/GLTFLoader.ts
@@ -12,15 +12,12 @@ export function loadGLTFModel(
         const loader = new GLTFLoader();
         const textureLoader = new THREE.TextureLoader();
 
+        let maxProgress = 0;
+
         loader.load(
             modelPath,
             async (gltf) => {
                 const model = gltf.scene;
-
-                // GLTF 로딩 완료 시 50%
-                if (onProgress) {
-                    onProgress(50);
-                }
 
                 const textureLoadPromises: Promise<void>[] = [];
                 const meshesWithTextures: Array<{
@@ -75,8 +72,12 @@ export function loadGLTFModel(
                             await promise;
                             loadedCount++;
                             const textureProgress = 50 + (loadedCount / totalTextures) * 50;
-                            if (onProgress) {
-                                onProgress(textureProgress);
+
+                            if (textureProgress > maxProgress) {
+                                maxProgress = textureProgress;
+                                if (onProgress) {
+                                    onProgress(textureProgress)
+                                }
                             }
                         })
                     );
@@ -100,14 +101,19 @@ export function loadGLTFModel(
                         animations: gltf.animations,
                     });
                 } catch (error) {
+                    console.error('❌ Texture loading failed:', error);
                     reject(error);
                 }
             },
             (xhr) => {
-                // GLTF 로딩은 0~50%
                 const percentComplete = (xhr.loaded / xhr.total) * 50;
-                if (onProgress) {
-                    onProgress(percentComplete);
+
+                if (percentComplete > maxProgress) {
+                    maxProgress = percentComplete;
+
+                    if (onProgress) {
+                        onProgress(percentComplete);
+                    }
                 }
             },
             reject


### PR DESCRIPTION
## 🛠️ 설명 (Description)

배포 환경에서 `LoadingScreen`의 진행률(progress)이
100% → 50%로 역행하는 버그를 수정했습니다.

### 🔎 문제 원인
- `GLTFLoader`의 `onLoad` 콜백에서 무조건 `onProgress(50)`을 호출
- `xhr.onProgress`에서 이미 50~100%까지 진행된 이후, `onLoad`가 실행되면 진행률이 100% → 50%로 감소

### 🛠️ 해결 방식
- `onLoad` 콜백 내부의 `onProgress(50)` 호출 제거
- `maxProgress` 상태값 도입
  - 진행률은 항상 증가할 때만 업데이트
  - 감소하는 값은 무시

## 📝 변경 사항 요약 (Summary)

- `GLTFLoader.ts`
  - `onLoad` 내부의 강제 `progress 50%` 설정 제거
  - `maxProgress` 변수 추가
  - 진행률 감소 방지 로직 추가

## 🔗 관련 이슈 (Related Issues)

- Closes #18 
- Related #None